### PR TITLE
indent: outdent after "continue" keyword and Lua "error" function

### DIFF
--- a/indent/moon.vim
+++ b/indent/moon.vim
@@ -41,7 +41,7 @@ let s:CONTINUATION_BLOCK = '[([{:=]$'
 let s:DOT_ACCESS = '^\.'
 
 " Keywords to outdent after
-let s:OUTDENT_AFTER = '^\%(return\|break\)\>'
+let s:OUTDENT_AFTER = '^\%(return\|break\|continue\|error\)\>'
 
 " A compound assignment like `... = if ...`
 let s:COMPOUND_ASSIGNMENT = '[:=]\s*\%(if\|unless\|for\|while\|'


### PR DESCRIPTION
For indenting, treat the Lua `error` function like the `return` and `break` keywords and outdent the following statements.
